### PR TITLE
ci(test): Run pre-push hooks

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,10 +33,12 @@ jobs:
         run: poetry install
       - name: Use Docker in rootless mode.
         uses: ScribeMD/rootless-docker@0.1.1
-      - name: Run pre-commit hooks.
+      - name: Run pre-push hooks.
         uses: pre-commit/action@v2.0.3
         env:
           SKIP: no-commit-to-branch
+        with:
+          extra_args: "--all-files --hook-stage push"
       - name: Send Slack notification with job status.
         if: always()
         uses: ScribeMD/slack-templates@0.1.2


### PR DESCRIPTION
This prevents MegaLinter from being run in incremental mode, which can sometimes miss issues. It also prevents jscpd from being skipped, since copy/paste detection fundamentally can't be performed incrementally.