### PR TITLE
ci(pre-commit): Don't duplicate MegaLinter args

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,9 +18,9 @@ repos:
       - id: poetry-install
       - id: pre-commit-install
       - id: megalinter
-        args: [--flavor, documentation, --release, v5.11.0]
+        args: &megalinter-args [--flavor, documentation, --release, v5.11.0]
       - id: megalinter-all
-        args: [--flavor, documentation, --release, v5.11.0]
+        args: *megalinter-args
 
   ## Markdown
   - repo: https://github.com/frnmst/md-toc


### PR DESCRIPTION
Use a YAML anchor and alias instead.