### PR TITLE
feat(pre-commit-install): Install default hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -73,22 +73,12 @@
     - push
     - post-checkout
   description: >
-    Install commit message, post-checkout, pre-commit, pre-merge commit, and
-    pre-push hooks. Also, install environments for all available hooks. Ensure
+    Install default hook types and environments for all available hooks. Ensure
     that updates to pre-commit's git hook script are applied. See
-    https://pre-commit.com/#pre-commit-install for more details.
-  args:
-    - --hook-type
-    - commit-msg
-    - --hook-type
-    - post-checkout
-    - --hook-type
-    - pre-commit
-    - --hook-type
-    - pre-merge-commit
-    - --hook-type
-    - pre-push
-    - --install-hooks
+    https://pre-commit.com/#pre-commit-install and
+    https://pre-commit.com/#top_level-default_install_hook_types for more
+    details.
+  args: [--install-hooks]
 
 - id: megalinter
   name: Run MegaLinter on files modified relative to default branch (skipping jscpd)

--- a/README.md
+++ b/README.md
@@ -72,20 +72,10 @@ Install Poetry dependencies from `poetry.lock` by running
 
 ### `pre-commit-install`
 
-Install pre-commit hooks by running:
-
-```sh
-pre-commit install \
-  --hook-type commit-msg \
-  --hook-type post-checkout \
-  --hook-type pre-commit \
-  --hook-type pre-merge-commit \
-  --hook-type pre-push \
-  --install-hooks
-```
-
-See the documentation for
-[`pre-commit install`](https://pre-commit.com/#pre-commit-install).
+Install pre-commit hooks by running
+[`pre-commit install --install-hooks`](https://pre-commit.com/#pre-commit-install).
+See also the documentation for
+[`default_install_hook_types`](https://pre-commit.com/#top_level-default_install_hook_types).
 
 ### `megalinter`
 


### PR DESCRIPTION
Pre-commit 2.18.0 introduced `default_install_hook_types`, allowing `.pre-commit-config.yaml` files to specify the hook types to install by default rather than requiring them to be passed on the command line. In light of this new feature, only install default hooks now. This is a breaking change for repositories relying on the explicit list of hooks we happened to install previously: `commit-msg`, `post-checkout`, `pre-commit`, `pre-merge-commit`, and `pre-push`.