### PR TITLE
ci(GitHub-Actions): Call slack-templates workflows

### DIFF
--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   bump-version:
-    name: Bump version, and update changelog with commitizen.
+    name: Bump Version
     if: "!startsWith(github.event.head_commit.message, 'bump:')"
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -6,23 +6,7 @@ on:
 jobs:
   bump-version:
     name: Bump Version
-    if: "!startsWith(github.event.head_commit.message, 'bump:')"
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check out repository.
-        uses: actions/checkout@v3.0.2
-        with:
-          fetch-depth: 0
-      - name: Push a commit to main to bump version and update changelog.
-        uses: commitizen-tools/commitizen-action@0.12.0
-        with:
-          branch: main
-          git_name: commitizen-github-action[bot]
-          git_email: commitizen-github-action[bot]@users.noreply.github.com
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Send Slack notification with job status.
-        uses: ScribeMD/slack-templates@0.2.3
-        with:
-          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel-id: ${{ secrets.SLACK_ACTIONS_CHANNEL_ID }}
-          template: result
+    uses: ScribeMD/slack-templates/.github/workflows/bump-version.yaml@0.2.3
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_ACTIONS_CHANNEL_ID: ${{ secrets.SLACK_ACTIONS_CHANNEL_ID }}

--- a/.github/workflows/bump-version.yaml
+++ b/.github/workflows/bump-version.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository.
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
       - name: Push a commit to main to bump version and update changelog.
@@ -21,7 +21,7 @@ jobs:
           git_email: commitizen-github-action[bot]@users.noreply.github.com
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Send Slack notification with job status.
-        uses: ScribeMD/slack-templates@0.1.2
+        uses: ScribeMD/slack-templates@0.2.3
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_ACTIONS_CHANNEL_ID }}

--- a/.github/workflows/notify-assignee.yaml
+++ b/.github/workflows/notify-assignee.yaml
@@ -6,11 +6,7 @@ on:
 jobs:
   notify-assignee:
     name: Notify Assignee
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Send Slack notification assigning pull request.
-        uses: ScribeMD/slack-templates@0.2.3
-        with:
-          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel-id: ${{ secrets.SLACK_ASSIGN_CHANNEL_ID }}
-          template: assignee
+    uses: ScribeMD/slack-templates/.github/workflows/notify-assignee.yaml@0.2.3
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_ASSIGN_CHANNEL_ID: ${{ secrets.SLACK_ASSIGN_CHANNEL_ID }}

--- a/.github/workflows/notify-assignee.yaml
+++ b/.github/workflows/notify-assignee.yaml
@@ -5,6 +5,7 @@ on:
       - assigned
 jobs:
   notify-assignee:
+    name: Notify Assignee
     runs-on: ubuntu-20.04
     steps:
       - name: Send Slack notification assigning pull request.

--- a/.github/workflows/notify-assignee.yaml
+++ b/.github/workflows/notify-assignee.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Send Slack notification assigning pull request.
-        uses: ScribeMD/slack-templates@0.1.2
+        uses: ScribeMD/slack-templates@0.2.3
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_ASSIGN_CHANNEL_ID }}

--- a/.github/workflows/notify-reviewers.yaml
+++ b/.github/workflows/notify-reviewers.yaml
@@ -5,6 +5,7 @@ on:
       - review_requested
 jobs:
   notify-reviewers:
+    name: Notify Reviewers
     runs-on: ubuntu-20.04
     steps:
       - name: Send Slack notification requesting code review.

--- a/.github/workflows/notify-reviewers.yaml
+++ b/.github/workflows/notify-reviewers.yaml
@@ -6,11 +6,7 @@ on:
 jobs:
   notify-reviewers:
     name: Notify Reviewers
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Send Slack notification requesting code review.
-        uses: ScribeMD/slack-templates@0.2.3
-        with:
-          bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel-id: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}
-          template: reviewers
+    uses: ScribeMD/slack-templates/.github/workflows/notify-reviewers.yaml@0.2.3
+    secrets:
+      SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+      SLACK_REVIEW_CHANNEL_ID: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}

--- a/.github/workflows/notify-reviewers.yaml
+++ b/.github/workflows/notify-reviewers.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Send Slack notification requesting code review.
-        uses: ScribeMD/slack-templates@0.1.2
+        uses: ScribeMD/slack-templates@0.2.3
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_REVIEW_CHANNEL_ID }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -8,6 +8,7 @@ on:
       - main
 jobs:
   test:
+    name: Run Pre-commit Hooks
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository.

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out repository.
-        uses: actions/checkout@v3.0.1
+        uses: actions/checkout@v3.0.2
         with:
           fetch-depth: 0
       - name: Install asdf-managed tools based on .tool-versions.
@@ -25,7 +25,7 @@ jobs:
           done
           echo "${{ github.workspace }}"/.venv/bin >> "$GITHUB_PATH"
       - name: Cache Poetry dependencies.
-        uses: actions/cache@v3.0.1
+        uses: actions/cache@v3.0.2
         with:
           path: .venv
           key: poetry-${{ runner.os }}-${{ hashFiles('poetry.lock') }}
@@ -41,7 +41,7 @@ jobs:
           extra_args: "--all-files --hook-stage push"
       - name: Send Slack notification with job status.
         if: always()
-        uses: ScribeMD/slack-templates@0.1.2
+        uses: ScribeMD/slack-templates@0.2.3
         with:
           bot-token: ${{ secrets.SLACK_BOT_TOKEN }}
           channel-id: ${{ secrets.SLACK_ACTIONS_CHANNEL_ID }}


### PR DESCRIPTION
Eliminate duplication of identical Notify Assignee, Notify Reviewers, and Bump Version workflows across repositories now that `slack-templates` houses callable versions.

Improve job names. They render within a small box in the GitHub Actions UI, and hence long names are elided. When not specified, they default to the job key, so specify them.

Upgrade GitHub Actions to latest versions.

actions/checkout v3.0.1 --> v3.0.2
actions/cache v3.0.1 --> v3.0.2
ScribeMD/slack-templates 0.1.1 --> 0.2.3