### PR TITLE
docs(pre-commit): Keep tool versions in sync

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_install_hook_types:
   - pre-merge-commit
   - pre-push
 default_language_version:
-  python: python3.10.4
+  python: python3.10.4 # Keep in sync with .tool-versions and pyproject.toml.
 default_stages:
   - commit
   - push
@@ -71,7 +71,7 @@ repos:
     hooks:
       - id: check-useless-excludes
   - repo: https://github.com/pre-commit/pre-commit
-    rev: v2.18.1
+    rev: v2.18.1 # Keep in sync with pyproject.toml.
     hooks:
       - id: validate_manifest
 

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 16.14.2
-python 3.10.4
+python 3.10.4 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
 poetry 1.1.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,10 @@ build-backend = "poetry.core.masonry.api"
   license = "MIT"
 
   [tool.poetry.dependencies]
+  # Keep in sync with .pre-commit-config.yaml and .tool-versions.
   python = "^3.10.4"
 
   [tool.poetry.dev-dependencies]
+  # Keep in sync with .pre-commit-config.yaml.
   commitizen = "^2.24.0"
   pre-commit = "^2.18.1"


### PR DESCRIPTION
Remind maintainers to keep the Python, pre-commit, and Commitizen versions used in sync since they are listed in several places.