### PR TITLE
style(gitignore): Omit trailing `/` for consistency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # MegaLinter
-report/
+report
 
 # Poetry
 .venv


### PR DESCRIPTION
Both `report` and `.venv` are directories, and a trailing `/` indicates that only directories should be matched. However, most directory names, including these, make poor choices of filenames because they lack extensions and would be prone to confusion with the identically named directories. Instructing Git to ignore such files adds a bit of friction to tracking such files.