### PR TITLE
docs(contributing): Remove `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,0 @@
-# Contributing Guide
-
-See [CONTRIBUTING.md of ScribeMD/slack-templates](https://github.com/ScribeMD/slack-templates/blob/main/CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ Hooks for Use With the [pre-commit](https://pre-commit.com) Framework
     - [`yarn-audit-licenses`](#yarn-audit-licenses)
     - [`yarn-build`](#yarn-build)
     - [`yarn-test`](#yarn-test)
-  - [Contributing](#contributing)
   - [Changelog](#changelog)
 
 <!--TOC-->
@@ -153,10 +152,6 @@ Run the `"test"` script in `package.json` via
 running
 [Jest tests that check the modified files](https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles),
 but the flag can be overridden.
-
-## Contributing
-
-Please refer to [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Changelog
 


### PR DESCRIPTION
It has been moved from slack-templates to the special .github repository. All repositories without their own contributing guide default to that shared guide.