### PR TITLE
fix(CSpell): Correct "Preform" to "Perform"

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,1 +1,2 @@
+!preform
 Laven

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -149,7 +149,7 @@
     specifications. See https://yarnpkg.com/cli/dedupe for more details.
 
 - id: yarn-audit
-  name: Preform security audit of Yarn dependencies
+  name: Perform security audit of Yarn dependencies
   entry: yarn npm audit
   language: system
   pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Deduplicate Yarn dependencies by running
 
 ### `yarn-audit`
 
-Preform security audit of Yarn dependencies by running
+Perform security audit of Yarn dependencies by running
 [`yarn npm audit --all --recursive`](https://yarnpkg.com/cli/npm/audit).
 
 ### `yarn-audit-licenses`

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -2,6 +2,7 @@ version: "0.2"
 language: en-US
 useGitignore: true
 ignorePaths:
+  - .dictionary.txt
   - .vscode
 dictionaryDefinitions:
   - name: custom


### PR DESCRIPTION
The former means forming something beforehand, while the latter means doing something. Add "preform" to the ban list since it will almost always be a typo.