### PR TITLE
fix(pre-commit): Run checkout hooks post-rewrite

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 default_install_hook_types:
   - commit-msg
   - post-checkout
+  - post-rewrite
   - pre-commit
   - pre-merge-commit
   - pre-push

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -20,6 +20,7 @@
     - commit
     - push
     - post-checkout
+    - post-rewrite
   description: >
     Install or set versions of asdf-managed tools based on .tool-versions unless
     otherwise configured. See
@@ -58,6 +59,7 @@
     - commit
     - push
     - post-checkout
+    - post-rewrite
   description: >
     Install all Poetry dependencies from poetry.lock. See
     https://python-poetry.org/docs/cli/#install for more details.
@@ -72,6 +74,7 @@
     - commit
     - push
     - post-checkout
+    - post-rewrite
   description: >
     Install default hook types and environments for all available hooks. Ensure
     that updates to pre-commit's git hook script are applied. See


### PR DESCRIPTION
`asdf-install`, `poetry-install`, and `pre-commit-install` already run post-checkout. Make them run post-rewrite as well. Hooks may be run at various points during a rebase, such as when amending or adding a commit, and the rebase may be across commits that modify tool versions. Git does not offer a post-rebase hook, but the post-rewrite hook runs after both rebases and amends. Also configure this repository to install post-rewrite hooks.