### PR TITLE
fix(pre-commit): Make `yarn-test` pass with no tests

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -191,7 +191,7 @@
   language: system
   types:
     - ts
-  args: [--findRelatedTests]
+  args: [--passWithNoTests, --findRelatedTests]
   description: >
     Run the Jest tests that check the modified files. See
     https://yarnpkg.com/cli/run and

--- a/README.md
+++ b/README.md
@@ -147,8 +147,8 @@ Run the `"build"` script in `package.json` via
 ### `yarn-test`
 
 Run the `"test"` script in `package.json` via
-[`yarn run test --findRelatedTests`](https://yarnpkg.com/cli/run). Useful for
-running
+[`yarn run test --passWithNoTests --findRelatedTests`](https://yarnpkg.com/cli/run).
+Useful for running
 [Jest tests that check the modified files](https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles),
 but the flag can be overridden.
 


### PR DESCRIPTION
Otherwise, it gives false positives when there are no tests related to the given files. As before, these default arguments can be overridden.