### PR TITLE
fix(pre-commit): Run `yarn-test` in one process

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -191,6 +191,7 @@
   language: system
   types:
     - ts
+  require_serial: true
   args: [--passWithNoTests, --findRelatedTests]
   description: >
     Run the Jest tests that check the modified files. See


### PR DESCRIPTION
Jest (and many other test runners) parallelize test execution. Instruct pre-commit not to run multiple instances of the test runner itself to prevent fork-bombing.