### PR TITLE
fix(pre-commit): Remove `--loose` from license audit

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -165,15 +165,12 @@
   name: Audit licenses of Yarn dependencies
   entry: yarn licenses audit
   language: system
-  files: \.tool-versions|package\.json|yarn(-*\.cjs|\.lock)|plugin-licenses-audit\.cjs
+  files: \.tool-versions|package\.json|yarn(-*\.cjs|\.lock)|plugin-licenses-audit\.cjs|\.licenses\.config\.ts
   pass_filenames: false
   description: >
     Check Yarn dependencies for license compatibility. See
     https://github.com/tophat/yarn-plugin-licenses for more details.
-  args:
-    - --output-file=reports/junit/licenses.xml
-    - --config=.licenses.config.ts
-    - --loose
+  args: [--output-file=reports/junit/licenses.xml, --config=.licenses.config.ts]
 
 - id: yarn-build
   name: Build the app

--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ Audit licenses of Yarn dependencies by running:
 yarn licenses audit \
   --output-file=reports/junit/licenses.xml
   --config=.licenses.config.ts
-  --loose
 ```
 
 See [the GitHub repo](https://github.com/tophat/yarn-plugin-licenses) for the


### PR DESCRIPTION
The `--loose` argument was previously required to inspect the contents of license files in packages that didn't properly declare their license in their `package.json`. We are no longer using any such packages, but the args can be overridden as needed. Also, run the `yarn-audit-licenses` hook when the license config file, `.licenses.config.ts`, is modified.