### PR TITLE
feat(MegaLinter): Upgrade from v5.15.0 to v5.16.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ repos:
       - id: poetry-install
       - id: pre-commit-install
       - id: megalinter
-        args: &megalinter-args [--flavor, documentation, --release, v5.15.0]
+        args: &megalinter-args [--flavor, documentation, --release, v5.16.1]
       - id: megalinter-all
         args: *megalinter-args
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -86,7 +86,7 @@
 - id: megalinter
   name: Run MegaLinter on files modified relative to default branch (skipping jscpd)
   entry: >
-    npx -- mega-linter-runner@v5.15.0
+    npx -- mega-linter-runner@v5.16.0
     --fix
     --env LOG_LEVEL=warning
     --env VALIDATE_ALL_CODEBASE=false
@@ -112,7 +112,7 @@
 - id: megalinter-all
   name: Run MegaLinter on all files
   entry: >
-    npx -- mega-linter-runner@v5.15.0
+    npx -- mega-linter-runner@v5.16.0
     --fix
     --env LOG_LEVEL=warning
   language: system


### PR DESCRIPTION
Upgrade MegaLinter Docker image from v5.15.0 to v5.16.1, but mega-linter-runner from v5.15.0 to v5.16.0 as there is no v5.16.1.