### PR TITLE
chore(GitHub-Actions): Upgrade to latest versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Run Pre-commit Hooks
-    uses: ScribeMD/pre-commit-action/.github/workflows/test.yaml@0.8.3
+    uses: ScribeMD/pre-commit-action/.github/workflows/test.yaml@0.8.4
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_ACTIONS_CHANNEL_ID: ${{ secrets.SLACK_ACTIONS_CHANNEL_ID }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,7 +78,7 @@ repos:
 
   ## Python
   - repo: https://github.com/Lucas-C/pre-commit-hooks-safety
-    rev: v1.2.4
+    rev: v1.3.0
     hooks:
       - id: python-safety-dependencies-check
 


### PR DESCRIPTION
ScribeMD/pre-commit-action 0.8.3 --> 0.8.4

Upgrade all pre-commit hooks to latest versions.

Lucas-C/pre-commit-hooks-safety v1.2.4 --> v1.3.0