### PR TITLE
docs(README): Update MegaLinter doc links to OX Security

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ on:
 jobs:
   test:
     name: Run Pre-commit Hooks
-    uses: ScribeMD/pre-commit-action/.github/workflows/test.yaml@0.8.6
+    uses: ScribeMD/pre-commit-action/.github/workflows/test.yaml@0.8.7
     secrets:
       SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
       SLACK_ACTIONS_CHANNEL_ID: ${{ secrets.SLACK_ACTIONS_CHANNEL_ID }}

--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ See also the documentation for
 
 ### `megalinter`
 
-Run [MegaLinter](https://megalinter.github.io/) on files modified relative to
-default branch (skipping jscpd) by running:
+Run [MegaLinter](https://oxsecurity.github.io/megalinter/) on files modified
+relative to default branch (skipping jscpd) by running:
 
 ```sh
 npx -- mega-linter-runner@<version> \
@@ -99,9 +99,9 @@ npx -- mega-linter-runner@<version> \
 ```
 
 See the documentation for
-[`mega-linter-runner`](https://megalinter.github.io/latest/mega-linter-runner/#usage)
+[`mega-linter-runner`](https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage)
 and
-[MegaLinter configuration](https://megalinter.github.io/latest/configuration/).
+[MegaLinter configuration](https://oxsecurity.github.io/megalinter/latest/configuration/).
 
 ### `megalinter-all`
 
@@ -114,9 +114,9 @@ npx -- mega-linter-runner@<version> \
 ```
 
 See the documentation for
-[`mega-linter-runner`](https://megalinter.github.io/latest/mega-linter-runner/#usage)
+[`mega-linter-runner`](https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage)
 and
-[MegaLinter configuration](https://megalinter.github.io/latest/configuration/).
+[MegaLinter configuration](https://oxsecurity.github.io/megalinter/latest/configuration/).
 
 ### `yarn-install`
 


### PR DESCRIPTION
MegaLinter is now sponsored by OX Security, and the documentation has been moved from https://megalinter.github.io/ to https://oxsecurity.github.io/megalinter accordingly.

Upgrade GitHub-Actions to latest versions.

ScribeMD/pre-commit-action 0.8.6 --> 0.8.7