### PR TITLE
feat(MegaLinter): Add v6 hooks at runner v6.7.1

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,2 +1,4 @@
 !preform
+containername
+filesonly
 Laven

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -111,6 +111,32 @@
     fundamentally requires scanning the entire repository and hence can't be
     performed incrementally.
 
+- id: megalinter-incremental
+  name: Run MegaLinter (skipping linters that run in project mode)
+  entry: >
+    npx -- mega-linter-runner@v6.7.1
+    --containername megalinter-$(basename "$PWD")
+    --remove-container
+    --fix
+    --env CLEAR_REPORT_FOLDER=true
+    --env LOG_LEVEL=warning
+    --filesonly
+  language: system
+  stages:
+    - commit
+  description: >
+    See https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage
+    and https://oxsecurity.github.io/megalinter/latest/configuration/ if you
+    wish to override the default arguments. mega-linter-runner is specified as
+    an argument so that you may override the version (e.g.,
+    mega-linter-runner@vx.y.z). Depends on npx, which ships with npm 7+, and
+    Docker. Runs very slowly when the pertinent Docker image isn't already
+    cached (c.f., https://github.com/marketplace/actions/docker-cache/). If you
+    encounter permission errors, try running Docker in rootless mode (c.f.,
+    https://github.com/marketplace/actions/rootless-docker/). Linter results are
+    logged to the megalinter-reports directory, so list it in your .gitignore.
+    Skip linters that run in project mode since they don't run incrementally.
+
 - id: megalinter-all
   name: Run MegaLinter on all files
   entry: >
@@ -131,6 +157,30 @@
     https://github.com/marketplace/actions/rootless-docker/. Linter results are
     logged to the report directory, so you should make sure to list it in your
     .gitignore and wipe it between runs.
+
+- id: megalinter-full
+  name: Run MegaLinter
+  entry: >
+    npx -- mega-linter-runner@v6.7.1
+    --containername "megalinter-all-$(basename "$PWD")"
+    --remove-container
+    --fix
+    --env CLEAR_REPORT_FOLDER=true
+    --env LOG_LEVEL=warning
+  language: system
+  stages:
+    - push
+  description: >
+    See https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage
+    and https://oxsecurity.github.io/megalinter/latest/configuration/ if you
+    wish to override the default arguments. mega-linter-runner is specified as
+    an argument so that you may override the version (e.g.,
+    mega-linter-runner@vx.y.z). Depends on npx, which ships with npm 7+, and
+    Docker. Runs very slowly when the pertinent Docker image isn't already
+    cached (c.f., https://github.com/marketplace/actions/docker-cache/). If you
+    encounter permission errors, try running Docker in rootless mode (c.f.,
+    https://github.com/marketplace/actions/rootless-docker/). Linter results are
+    logged to the megalinter-reports directory, so list it in your .gitignore.
 
 - id: yarn-install
   name: Install Yarn dependencies

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ Hooks for Use With the [pre-commit](https://pre-commit.com) Framework
     - [`poetry-install`](#poetry-install)
     - [`pre-commit-install`](#pre-commit-install)
     - [`megalinter`](#megalinter)
+    - [`megalinter-incremental`](#megalinter-incremental)
     - [`megalinter-all`](#megalinter-all)
+    - [`megalinter-full`](#megalinter-full)
     - [`yarn-install`](#yarn-install)
     - [`yarn-dedupe`](#yarn-dedupe)
     - [`yarn-audit`](#yarn-audit)
@@ -88,6 +90,7 @@ See also the documentation for
 
 ### `megalinter`
 
+This hook is intended for MegaLinter v5.
 Run [MegaLinter](https://oxsecurity.github.io/megalinter/) on files modified
 relative to default branch (skipping jscpd) by running:
 
@@ -104,14 +107,52 @@ See the documentation for
 and
 [MegaLinter configuration](https://oxsecurity.github.io/megalinter/latest/configuration/).
 
+### `megalinter-incremental`
+
+This hook is intended for MegaLinter v6. Run MegaLinter (skipping linters that
+run in project mode) by running:
+
+```sh
+npx -- mega-linter-runner@<version> \
+  --containername megalinter-$(basename "$PWD") \
+  --remove-container \
+  --fix \
+  --env CLEAR_REPORT_FOLDER=true \
+  --env LOG_LEVEL=warning \
+  --filesonly
+```
+
+See the documentation for
+[`mega-linter-runner`](https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage)
+and
+[MegaLinter configuration](https://oxsecurity.github.io/megalinter/latest/configuration/).
+
 ### `megalinter-all`
 
-Run MegaLinter on all files by running:
+This hook is intended for MegaLinter v5. Run MegaLinter on all files by running:
 
 ```sh
 npx -- mega-linter-runner@<version> \
   --fix \
   --env LOG_LEVEL=warning
+```
+
+See the documentation for
+[`mega-linter-runner`](https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage)
+and
+[MegaLinter configuration](https://oxsecurity.github.io/megalinter/latest/configuration/).
+
+### `megalinter-full`
+
+This hook is intended for MegaLinter v6. Run MegaLinter by running:
+
+```sh
+npx -- mega-linter-runner@<version> \
+  --containername "megalinter-all-$(basename "$PWD")" \
+  --remove-container \
+  --fix \
+  --env CLEAR_REPORT_FOLDER=true \
+  --env LOG_LEVEL=warning \
 ```
 
 See the documentation for


### PR DESCRIPTION
Add v6 `megalinter-incremental` hook that only runs on the modified files, skipping all linters that run in project mode. This is an upgraded version of the v5 `megalinter` hook. Add v6 `megalinter-full` hook that runs only on the modified files when supported, but also runs linters that run in project mode. This is an upgraded version of the v5 `megalinter-all` hook. This brings MegaLinter's pre-commit hooks more in line with typical hooks, which run on the files passed by pre-commit rather than running `git diff` themselves.

Leverage new v6 features to automatically clean up the Docker container and `megalinter-reports` directory, and give a meaningful name to the Docker container rather than one randomly generated by Docker.