### PR TITLE
feat(Poetry): Upgrade from 1.1.15 to 1.2.0

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -61,8 +61,10 @@
     - post-checkout
     - post-rewrite
   description: >
-    Install all Poetry dependencies from poetry.lock. See
+    Install all Poetry dependencies from poetry.lock. Uninstall any dependencies
+    not found in the lock file. Requires Poetry 1.2+. See
     https://python-poetry.org/docs/cli/#install for more details.
+  args: [--sync]
 
 - id: pre-commit-install
   name: Install pre-commit hooks

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 nodejs 16.17.0
 python 3.10.6 # Keep in sync with .pre-commit-config.yaml and pyproject.toml.
-poetry 1.1.15
+poetry 1.2.0

--- a/README.md
+++ b/README.md
@@ -76,7 +76,8 @@ but the file pattern may be overridden).
 ### `poetry-install`
 
 Install Poetry dependencies from `poetry.lock` by running
-[`poetry install`](https://python-poetry.org/docs/cli/#install).
+[`poetry install --sync`](https://python-poetry.org/docs/cli/#install).
+Uninstall any dependencies not found in the lock file. Requires Poetry 1.2+.
 
 ### `pre-commit-install`
 


### PR DESCRIPTION
Pass new `--sync` argument in `poetry-install` hook to remove any dependencies not found in `poetry.lock` from the virtual environment.