### PR TITLE
fix(MegaLinter): Run serially in v6 hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -124,6 +124,7 @@
   language: system
   stages:
     - commit
+  require_serial: true
   description: >
     See https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage
     and https://oxsecurity.github.io/megalinter/latest/configuration/ if you
@@ -170,6 +171,7 @@
   language: system
   stages:
     - push
+  require_serial: true
   description: >
     See https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage
     and https://oxsecurity.github.io/megalinter/latest/configuration/ if you


### PR DESCRIPTION
MegaLinter runs linters in parallel. Instruct pre-commit not to run multiple instances of MegaLinter itself to prevent fork-bombing. This also prevents the `megalinter-full` hook from redundantly running each project linter once per MegaLinter invocation, which is both wasteful and can lead to race conditions.