### PR TITLE
fix(MegaLinter): Fix Docker container names

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -115,7 +115,7 @@
   name: Run MegaLinter (skipping linters that run in project mode)
   entry: >
     npx -- mega-linter-runner@v6.10.0
-    --containername megalinter-$(basename "$PWD")
+    --containername megalinter-incremental
     --remove-container
     --fix
     --env CLEAR_REPORT_FOLDER=true
@@ -163,7 +163,7 @@
   name: Run MegaLinter
   entry: >
     npx -- mega-linter-runner@v6.10.0
-    --containername "megalinter-all-$(basename "$PWD")"
+    --containername megalinter-full
     --remove-container
     --fix
     --env CLEAR_REPORT_FOLDER=true


### PR DESCRIPTION
The previous Docker container names contained Bash syntax, but pre-commit interprets them as string literals, resulting in invalid Docker container names. Remove Bash syntax, and replace it with string literals.