### PR TITLE
fix(yarn-install): Run post-checkout/rewrite

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -141,8 +141,13 @@
   name: Install Yarn dependencies
   entry: yarn install
   language: system
-  files: \.tool-versions|package\.json|yarn(-.*\.cjs|\.lock)
+  always_run: true
   pass_filenames: false
+  stages:
+    - commit
+    - push
+    - post-checkout
+    - post-rewrite
   description: >
     Install all Yarn dependencies, and update yarn.lock. See
     https://yarnpkg.com/cli/install for more details.


### PR DESCRIPTION
Run the `yarn-install` hook after switching branches, rebasing, etc. like the `asdf-install` and `poetry-install` hooks to ensure the development environment remains in sync with version control.