### PR TITLE
docs(poetry-lock): Update link to Poetry docs

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -44,7 +44,7 @@
   pass_filenames: false
   description: >
     Update poetry.lock to match pyproject.toml without upgrading already locked
-    dependencies. See https://python-poetry.org/docs/cli/#options-9 for more
+    dependencies. See https://python-poetry.org/docs/cli/#lock for more
     details.
   args: [--no-update]
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ Poetry is managed by asdf, but the file pattern may be overridden).
 
 Update `poetry.lock` to match `pyproject.toml` without upgrading already locked
 dependencies by running
-[`poetry lock --no-update`](https://python-poetry.org/docs/cli/#options-9). Run
-when Poetry dependencies or version changes (assuming Poetry is managed by asdf,
-but the file pattern may be overridden).
+[`poetry lock --no-update`](https://python-poetry.org/docs/cli/#lock). Run when
+Poetry dependencies or version changes (assuming Poetry is managed by asdf, but
+the file pattern may be overridden).
 
 ### `poetry-install`
 


### PR DESCRIPTION
Options were added to the `new` command in Poetry 1.2.0, so https://python-poetry.org/docs/cli/#options-9 began pointing to the options for the `config` command, rather than the `lock` command, which now reside at https://python-poetry.org/docs/cli/#options-10. Link to the `lock` command rather than its options so this issue doesn't recur.