### PR TITLE
ci(pre-commit): Remove `version_files` lookahead

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "poetry.core.masonry.api"
   [tool.commitizen]
   version = "0.13.1"
   version_files = [
-    ".pre-commit-config.yaml:rev:\\s+(?=[^\\n]+Commitizen)",
+    ".pre-commit-config.yaml:rev:.+Commitizen",
     "pyproject.toml:version"
   ]
 


### PR DESCRIPTION
We run Commitizen bump to, among other things, manage the version pre-commit-hooks uses of its own pre-commit hooks. When searching `.pre-commit-config.yaml` for the version number of pre-commit-hooks, we search for "Commitizen," which is in a comment to the right of the version number. Remove the lookahead assertion for "Commitizen," and instead simply consume it when matching now that `version_files` regexes don't need to exclusively match to the left of the version number.