### PR TITLE
feat(MegaLinter): Upgrade from v6.10.0 to v6.12.0

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -3,7 +3,7 @@
   "maxSize": 0,
   "threshold": 0,
   "reporters": ["consoleFull", "console"],
-  "ignore": [".git", ".venv"],
+  "ignore": ["**/.git", "**/.venv"],
   "gitignore": true,
   "blame": true,
   "ignoreCase": true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
       - id: poetry-install
       - id: pre-commit-install
       - id: megalinter-incremental
-        args: &megalinter-args [--flavor, documentation, --release, v6.10.0]
+        args: &megalinter-args [--flavor, documentation, --release, v6.12.0]
       - id: megalinter-full
         args: *megalinter-args
 

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -87,8 +87,8 @@
 - id: megalinter-incremental
   name: Run MegaLinter (skipping linters that run in project mode)
   entry: >
-    npx -- mega-linter-runner@v6.10.0
-    --containername megalinter-incremental
+    npx -- mega-linter-runner@v6.12.0
+    --container-name megalinter-incremental
     --remove-container
     --fix
     --env CLEAR_REPORT_FOLDER=true
@@ -114,8 +114,8 @@
 - id: megalinter-full
   name: Run MegaLinter
   entry: >
-    npx -- mega-linter-runner@v6.10.0
-    --containername megalinter-full
+    npx -- mega-linter-runner@v6.12.0
+    --container-name megalinter-full
     --remove-container
     --fix
     --env CLEAR_REPORT_FOLDER=true

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ This hook is intended for MegaLinter v6. Run [MegaLinter](https://oxsecurity.git
 
 ```sh
 npx -- mega-linter-runner@<version> \
-  --containername megalinter-incremental \
+  --container-name megalinter-incremental \
   --remove-container \
   --fix \
   --env CLEAR_REPORT_FOLDER=true \
@@ -112,7 +112,7 @@ This hook is intended for MegaLinter v6. Run MegaLinter by running:
 
 ```sh
 npx -- mega-linter-runner@<version> \
-  --containername megalinter-full \
+  --container-name megalinter-full \
   --remove-container \
   --fix \
   --env CLEAR_REPORT_FOLDER=true \


### PR DESCRIPTION
Correct spelling of `containername` argument to `container-name` now that it has been corrected upstream Update jscpd ignore syntax to continue preventing jscpd from running on the `.git` directory or Poetry virtual environment.