### PR TITLE
fix(MegaLinter): Stop setting `CLEAR_REPORT_FOLDER`

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -91,7 +91,6 @@
     --container-name megalinter-incremental
     --remove-container
     --fix
-    --env CLEAR_REPORT_FOLDER=true
     --env LOG_LEVEL=warning
     --filesonly
   language: system
@@ -118,7 +117,6 @@
     --container-name megalinter-full
     --remove-container
     --fix
-    --env CLEAR_REPORT_FOLDER=true
     --env LOG_LEVEL=warning
   language: system
   stages:

--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ npx -- mega-linter-runner@<version> \
   --container-name megalinter-incremental \
   --remove-container \
   --fix \
-  --env CLEAR_REPORT_FOLDER=true \
   --env LOG_LEVEL=warning \
   --filesonly
 ```
@@ -115,7 +114,6 @@ npx -- mega-linter-runner@<version> \
   --container-name megalinter-full \
   --remove-container \
   --fix \
-  --env CLEAR_REPORT_FOLDER=true \
   --env LOG_LEVEL=warning \
 ```
 


### PR DESCRIPTION
Respect the setting of `CLEAR_REPORT_FOLDER` in the caller's MegaLinter config file rather than override it to `true`.