### PR TITLE
docs(mega-linter-runner): Show version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ This hook is intended for MegaLinter v6. Run [MegaLinter](https://oxsecurity.git
 (skipping linters that run in project mode) by running:
 
 ```sh
-npx -- mega-linter-runner@<version> \
+npx -- mega-linter-runner@v6.13.0 \
   --container-name megalinter-incremental \
   --remove-container \
   --fix \
@@ -110,7 +110,7 @@ and
 This hook is intended for MegaLinter v6. Run MegaLinter by running:
 
 ```sh
-npx -- mega-linter-runner@<version> \
+npx -- mega-linter-runner@v6.13.0 \
   --container-name megalinter-full \
   --remove-container \
   --fix \


### PR DESCRIPTION
We plan to port from Dependabot to Renovate soon, and the latter can be configured to automatically bump the version of mega-linter-runner displayed in the documentation.