### PR TITLE
chore(Renovate): Use fix for MegaLinter bumps

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ScribeMD/.github#0.7.10"]
+  "extends": ["github>ScribeMD/.github#0.7.10"],
+  "packageRules": [
+    {
+      "matchPackagePatterns": ["[Mm]ega-?[Ll]inter"],
+      "groupName": "MegaLinter",
+      "semanticCommitType": "fix"
+    }
+  ]
 }


### PR DESCRIPTION
Our shared Renovate config also groups MegaLinter bumps, but as chore rather than fix commits, because Renovate chooses the commit type associated with the first dependency in the group. Dependencies are sorted first by update type, then by manager name, and finally by package filename. Because of the final tiebreaker, the MegaLinter Docker image listed in `.pre-commit-config.yaml` sorts before the mega-linter-runner npm package listed in `.pre-commit-hooks.yaml` and `README.md`. Since the MegaLinter Docker image is a development dependency, the commit type of chore was used. Configure the MegaLinter group to use the fix commit type explicitly since the Docker image is almost always accompanied by a corresponding release to the npm package.