### PR TITLE
docs(MegaLinter): Update MegaLinter doc links

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -98,14 +98,14 @@
     - commit
   require_serial: true
   description: >
-    See https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage
-    and https://oxsecurity.github.io/megalinter/latest/configuration/ if you
-    wish to override the default arguments. mega-linter-runner is specified as
-    an argument so that you may override the version (e.g.,
-    mega-linter-runner@vx.y.z). Depends on npx, which ships with npm 7+, and
-    Docker. Runs very slowly when the pertinent Docker image isn't already
-    cached (c.f., https://github.com/marketplace/actions/docker-cache/). If you
-    encounter permission errors, try running Docker in rootless mode (c.f.,
+    See https://megalinter.io/latest/mega-linter-runner/#usage and
+    https://megalinter.io/latest/configuration/ if you wish to override the
+    default arguments. mega-linter-runner is specified as an argument so that
+    you may override the version (e.g., mega-linter-runner@vx.y.z). Depends on
+    npx, which ships with npm 7+, and Docker. Runs very slowly when the
+    pertinent Docker image isn't already cached (c.f.,
+    https://github.com/marketplace/actions/docker-cache/). If you encounter
+    permission errors, try running Docker in rootless mode (c.f.,
     https://github.com/marketplace/actions/rootless-docker/). Linter results are
     logged to the megalinter-reports directory, so list it in your .gitignore.
     Skip linters that run in project mode since they don't run incrementally.
@@ -123,14 +123,14 @@
     - push
   require_serial: true
   description: >
-    See https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage
-    and https://oxsecurity.github.io/megalinter/latest/configuration/ if you
-    wish to override the default arguments. mega-linter-runner is specified as
-    an argument so that you may override the version (e.g.,
-    mega-linter-runner@vx.y.z). Depends on npx, which ships with npm 7+, and
-    Docker. Runs very slowly when the pertinent Docker image isn't already
-    cached (c.f., https://github.com/marketplace/actions/docker-cache/). If you
-    encounter permission errors, try running Docker in rootless mode (c.f.,
+    See https://megalinter.io/latest/mega-linter-runner/#usage and
+    https://megalinter.io/latest/configuration/ if you wish to override the
+    default arguments. mega-linter-runner is specified as an argument so that
+    you may override the version (e.g., mega-linter-runner@vx.y.z). Depends on
+    npx, which ships with npm 7+, and Docker. Runs very slowly when the
+    pertinent Docker image isn't already cached (c.f.,
+    https://github.com/marketplace/actions/docker-cache/). If you encounter
+    permission errors, try running Docker in rootless mode (c.f.,
     https://github.com/marketplace/actions/rootless-docker/). Linter results are
     logged to the megalinter-reports directory, so list it in your .gitignore.
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See also the documentation for
 
 ### `megalinter-incremental`
 
-This hook is intended for MegaLinter v6. Run [MegaLinter](https://oxsecurity.github.io/megalinter/)
+This hook is intended for MegaLinter v6. Run [MegaLinter](https://megalinter.io/)
 (skipping linters that run in project mode) by running:
 
 ```sh
@@ -101,9 +101,9 @@ npx -- mega-linter-runner@v6.19.0 \
 ```
 
 See the documentation for
-[`mega-linter-runner`](https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage)
+[`mega-linter-runner`](https://megalinter.io/latest/mega-linter-runner/#usage)
 and
-[MegaLinter configuration](https://oxsecurity.github.io/megalinter/latest/configuration/).
+[MegaLinter configuration](https://megalinter.io/latest/configuration/).
 
 ### `megalinter-full`
 
@@ -118,9 +118,9 @@ npx -- mega-linter-runner@v6.19.0 \
 ```
 
 See the documentation for
-[`mega-linter-runner`](https://oxsecurity.github.io/megalinter/latest/mega-linter-runner/#usage)
+[`mega-linter-runner`](https://megalinter.io/latest/mega-linter-runner/#usage)
 and
-[MegaLinter configuration](https://oxsecurity.github.io/megalinter/latest/configuration/).
+[MegaLinter configuration](https://megalinter.io/latest/configuration/).
 
 ### `yarn-install`
 


### PR DESCRIPTION
The MegaLinter documentation has been moved from https://oxsecurity.github.io/megalinter/ to https://megalinter.io/.