### PR TITLE
fix(yarn-audit-licenses): Remove this hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -170,17 +170,6 @@
     https://yarnpkg.com/cli/npm/audit for more details.
   args: [--all, --recursive]
 
-- id: yarn-audit-licenses
-  name: Audit licenses of Yarn dependencies
-  entry: yarn licenses audit
-  language: system
-  files: \.tool-versions|package\.json|yarn(-*\.cjs|\.lock)|plugin-licenses-audit\.cjs|\.licenses\.config\.ts
-  pass_filenames: false
-  description: >
-    Check Yarn dependencies for license compatibility. See
-    https://github.com/tophat/yarn-plugin-licenses for more details.
-  args: [--output-file=reports/junit/licenses.xml, --config=.licenses.config.ts]
-
 - id: yarn-build
   name: Build the app
   entry: yarn run build

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Hooks for Use With the [pre-commit](https://pre-commit.com) Framework
     - [`yarn-install`](#yarn-install)
     - [`yarn-dedupe`](#yarn-dedupe)
     - [`yarn-audit`](#yarn-audit)
-    - [`yarn-audit-licenses`](#yarn-audit-licenses)
     - [`yarn-build`](#yarn-build)
     - [`yarn-test`](#yarn-test)
   - [Changelog](#changelog)
@@ -136,19 +135,6 @@ Deduplicate Yarn dependencies by running
 
 Perform security audit of Yarn dependencies by running
 [`yarn npm audit --all --recursive`](https://yarnpkg.com/cli/npm/audit).
-
-### `yarn-audit-licenses`
-
-Audit licenses of Yarn dependencies by running:
-
-```sh
-yarn licenses audit \
-  --output-file=reports/junit/licenses.xml
-  --config=.licenses.config.ts
-```
-
-See [the GitHub repo](https://github.com/tophat/yarn-plugin-licenses) for the
-Yarn licenses plugin.
 
 ### `yarn-build`
 


### PR DESCRIPTION
We ported from the Yarn licenses-audit plugin to Pivotal's LicenseFinder, which offers its own pre-commit hook. licenses-audit doesn't support any version of Yarn above v3.0.0, which just reached EOL (end-of-life). LicenseFinder also provides support for numerous other package managers in addition to Yarn.