### PR TITLE
style(MegaLinter): Move after Yarn hooks

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -84,56 +84,6 @@
     details.
   args: [--install-hooks]
 
-- id: megalinter-incremental
-  name: Run MegaLinter (skipping linters that run in project mode)
-  entry: >
-    npx -- mega-linter-runner@v7.2.1
-    --container-name megalinter-incremental
-    --remove-container
-    --fix
-    --env LOG_LEVEL=warning
-    --filesonly
-  language: system
-  stages:
-    - commit
-  require_serial: true
-  description: >
-    See https://megalinter.io/latest/mega-linter-runner/#usage and
-    https://megalinter.io/latest/configuration/ if you wish to override the
-    default arguments. mega-linter-runner is specified as an argument so that
-    you may override the version (e.g., mega-linter-runner@vx.y.z). Depends on
-    npx, which ships with npm 7+, and Docker. Runs very slowly when the
-    pertinent Docker image isn't already cached (c.f.,
-    https://github.com/marketplace/actions/docker-cache/). If you encounter
-    permission errors, try running Docker in rootless mode (c.f.,
-    https://github.com/marketplace/actions/rootless-docker/). Linter results are
-    logged to the megalinter-reports directory, so list it in your .gitignore.
-    Skip linters that run in project mode since they don't run incrementally.
-
-- id: megalinter-full
-  name: Run MegaLinter
-  entry: >
-    npx -- mega-linter-runner@v7.2.1
-    --container-name megalinter-full
-    --remove-container
-    --fix
-    --env LOG_LEVEL=warning
-  language: system
-  stages:
-    - push
-  require_serial: true
-  description: >
-    See https://megalinter.io/latest/mega-linter-runner/#usage and
-    https://megalinter.io/latest/configuration/ if you wish to override the
-    default arguments. mega-linter-runner is specified as an argument so that
-    you may override the version (e.g., mega-linter-runner@vx.y.z). Depends on
-    npx, which ships with npm 7+, and Docker. Runs very slowly when the
-    pertinent Docker image isn't already cached (c.f.,
-    https://github.com/marketplace/actions/docker-cache/). If you encounter
-    permission errors, try running Docker in rootless mode (c.f.,
-    https://github.com/marketplace/actions/rootless-docker/). Linter results are
-    logged to the megalinter-reports directory, so list it in your .gitignore.
-
 - id: yarn-install
   name: Install Yarn dependencies
   entry: yarn install
@@ -193,3 +143,53 @@
     https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles
     for more details.
   args: [--passWithNoTests, --findRelatedTests]
+
+- id: megalinter-incremental
+  name: Run MegaLinter (skipping linters that run in project mode)
+  entry: >
+    npx -- mega-linter-runner@v7.2.1
+    --container-name megalinter-incremental
+    --remove-container
+    --fix
+    --env LOG_LEVEL=warning
+    --filesonly
+  language: system
+  stages:
+    - commit
+  require_serial: true
+  description: >
+    See https://megalinter.io/latest/mega-linter-runner/#usage and
+    https://megalinter.io/latest/configuration/ if you wish to override the
+    default arguments. mega-linter-runner is specified as an argument so that
+    you may override the version (e.g., mega-linter-runner@vx.y.z). Depends on
+    npx, which ships with npm 7+, and Docker. Runs very slowly when the
+    pertinent Docker image isn't already cached (c.f.,
+    https://github.com/marketplace/actions/docker-cache/). If you encounter
+    permission errors, try running Docker in rootless mode (c.f.,
+    https://github.com/marketplace/actions/rootless-docker/). Linter results are
+    logged to the megalinter-reports directory, so list it in your .gitignore.
+    Skip linters that run in project mode since they don't run incrementally.
+
+- id: megalinter-full
+  name: Run MegaLinter
+  entry: >
+    npx -- mega-linter-runner@v7.2.1
+    --container-name megalinter-full
+    --remove-container
+    --fix
+    --env LOG_LEVEL=warning
+  language: system
+  stages:
+    - push
+  require_serial: true
+  description: >
+    See https://megalinter.io/latest/mega-linter-runner/#usage and
+    https://megalinter.io/latest/configuration/ if you wish to override the
+    default arguments. mega-linter-runner is specified as an argument so that
+    you may override the version (e.g., mega-linter-runner@vx.y.z). Depends on
+    npx, which ships with npm 7+, and Docker. Runs very slowly when the
+    pertinent Docker image isn't already cached (c.f.,
+    https://github.com/marketplace/actions/docker-cache/). If you encounter
+    permission errors, try running Docker in rootless mode (c.f.,
+    https://github.com/marketplace/actions/rootless-docker/). Linter results are
+    logged to the megalinter-reports directory, so list it in your .gitignore.

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Hooks for Use With the [pre-commit](https://pre-commit.com) Framework
     - [`poetry-lock`](#poetry-lock)
     - [`poetry-install`](#poetry-install)
     - [`pre-commit-install`](#pre-commit-install)
-    - [`megalinter-incremental`](#megalinter-incremental)
-    - [`megalinter-full`](#megalinter-full)
     - [`yarn-install`](#yarn-install)
     - [`yarn-dedupe`](#yarn-dedupe)
     - [`yarn-audit`](#yarn-audit)
     - [`yarn-build`](#yarn-build)
     - [`yarn-test`](#yarn-test)
+    - [`megalinter-incremental`](#megalinter-incremental)
+    - [`megalinter-full`](#megalinter-full)
   - [Changelog](#changelog)
 
 <!--TOC-->
@@ -85,6 +85,34 @@ Install pre-commit hooks by running
 See also the documentation for
 [`default_install_hook_types`](https://pre-commit.com/#top_level-default_install_hook_types).
 
+### `yarn-install`
+
+Install Yarn dependencies, and update `yarn.lock` by running
+[`yarn install`](https://yarnpkg.com/cli/install).
+
+### `yarn-dedupe`
+
+Deduplicate Yarn dependencies by running
+[`yarn dedupe`](https://yarnpkg.com/cli/dedupe).
+
+### `yarn-audit`
+
+Perform security audit of Yarn dependencies by running
+[`yarn npm audit --all --recursive`](https://yarnpkg.com/cli/npm/audit).
+
+### `yarn-build`
+
+Run the `"build"` script in `package.json` via
+[`yarn run build`](https://yarnpkg.com/cli/run).
+
+### `yarn-test`
+
+Run the `"test"` script in `package.json` via
+[`yarn run test --passWithNoTests --findRelatedTests`](https://yarnpkg.com/cli/run).
+Useful for running
+[Jest tests that check the modified files](https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles),
+but the flag can be overridden.
+
 ### `megalinter-incremental`
 
 This hook is intended for MegaLinter v6. Run
@@ -121,34 +149,6 @@ See the documentation for
 [`mega-linter-runner`](https://megalinter.io/latest/mega-linter-runner/#usage)
 and
 [MegaLinter configuration](https://megalinter.io/latest/configuration/).
-
-### `yarn-install`
-
-Install Yarn dependencies, and update `yarn.lock` by running
-[`yarn install`](https://yarnpkg.com/cli/install).
-
-### `yarn-dedupe`
-
-Deduplicate Yarn dependencies by running
-[`yarn dedupe`](https://yarnpkg.com/cli/dedupe).
-
-### `yarn-audit`
-
-Perform security audit of Yarn dependencies by running
-[`yarn npm audit --all --recursive`](https://yarnpkg.com/cli/npm/audit).
-
-### `yarn-build`
-
-Run the `"build"` script in `package.json` via
-[`yarn run build`](https://yarnpkg.com/cli/run).
-
-### `yarn-test`
-
-Run the `"test"` script in `package.json` via
-[`yarn run test --passWithNoTests --findRelatedTests`](https://yarnpkg.com/cli/run).
-Useful for running
-[Jest tests that check the modified files](https://jestjs.io/docs/cli#--findrelatedtests-spaceseparatedlistofsourcefiles),
-but the flag can be overridden.
 
 ## Changelog
 


### PR DESCRIPTION
We recently reordered the MegaLinter hooks after the Yarn hooks in our `.pre-commit-config.yaml` files since `yarn-install` must now precede MegaLinter so that ESLint can run. Reflect the new order in `.pre-commit-hooks.yaml` and the README for consistency.