### PR TITLE
fix(Yarn): Correct regular expressions for Yarn releases

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -103,7 +103,7 @@
   name: Deduplicate Yarn dependencies
   entry: yarn dedupe
   language: system
-  files: \.tool-versions|package\.json|yarn(-*\.cjs|\.lock)
+  files: \.tool-versions|package\.json|yarn(-(\d+\.){2}\d+\.cjs|\.lock)
   pass_filenames: false
   description: >
     Remove all but the highest version of any duplicates. More than one version
@@ -124,7 +124,7 @@
   name: Build the app
   entry: yarn run build
   language: system
-  files: \.tool-versions|package\.json|yarn(-*\.cjs|\.lock)|.*\.ts
+  files: \.tool-versions|package\.json|yarn(-(\d+\.){2}\d+\.cjs|\.lock)|.*\.ts
   pass_filenames: false
   description: >
     Compile TypeScript files to JavaScript. See https://yarnpkg.com/cli/run for


### PR DESCRIPTION
The `yarn-dedupe` and `yarn-build` hooks both intended to run on Yarn upgrades/downgrades. They both used an asterisk (`*`) to match the Yarn version number as if pre-commit expected a glob pattern rather than a Python regular expression. Replacing `*` with `.*` would correct this mistake but also leave the regular expressions overly broad. Prefer `(\d+\.){2}\d+` to only match version numbers and avoid false positives.