### PR TITLE
feat(yarn-sdks): Add hook to generate Yarn SDKs

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -120,6 +120,18 @@
     https://yarnpkg.com/cli/npm/audit for more details.
   args: [--all, --recursive]
 
+- id: yarn-sdks
+  name: Generate Yarn SDKs
+  entry: src/yarn-sdks.sh
+  language: script
+  files: \.yarn/sdks/|yarn(-(\d+\.){2}\d+\.cjs|\.lock)
+  pass_filenames: false
+  description: >
+    Generate SDKs and settings for editors specified in
+    `.yarn/sdks/integrations.yml`. Format VSCode settings with Prettier to
+    prevent formatting conflicts with MegaLinter. See
+    https://yarnpkg.com/sdks/cli/default for more details.
+
 - id: yarn-build
   name: Build the app
   entry: yarn run build

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Hooks for Use With the [pre-commit](https://pre-commit.com) Framework
     - [`yarn-install`](#yarn-install)
     - [`yarn-dedupe`](#yarn-dedupe)
     - [`yarn-audit`](#yarn-audit)
+    - [`yarn-sdks`](#yarn-sdks)
     - [`yarn-build`](#yarn-build)
     - [`yarn-test`](#yarn-test)
     - [`megalinter-incremental`](#megalinter-incremental)
@@ -99,6 +100,14 @@ Deduplicate Yarn dependencies by running
 
 Perform security audit of Yarn dependencies by running
 [`yarn npm audit --all --recursive`](https://yarnpkg.com/cli/npm/audit).
+
+### `yarn-sdks`
+
+Generate SDKs and settings for editors specified in
+`.yarn/sdks/integrations.yml` by running
+[`yarn run sdks && yarn run prettier --write .vscode/settings.json`](https://yarnpkg.com/sdks/cli/default).
+Format VSCode settings with Prettier to prevent formatting conflicts with
+MegaLinter.
 
 ### `yarn-build`
 

--- a/src/yarn-sdks.sh
+++ b/src/yarn-sdks.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -o errexit -o noglob -o pipefail -o nounset
+
+yarn run sdks
+yarn run prettier --write .vscode/settings.json


### PR DESCRIPTION
Ensure Yarn SDKs remain up-to-date. Run Prettier on VSCode settings within the same hook to prevent formatting conflicts with MegaLinter, which also runs Prettier. Define the hook as a script since system hooks don't support running multiple commands.