### PR TITLE
ci(dictionary): Remove "regexes" from dictionary

### DIFF
--- a/.dictionary.txt
+++ b/.dictionary.txt
@@ -1,4 +1,3 @@
 !preform
 filesonly
 Laven
-regexes


### PR DESCRIPTION
It was added to the software-terms dictionary upstream.