### PR TITLE
docs(pyproject): Correct position of sync comment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,5 +20,6 @@ build-backend = "poetry.core.masonry.api"
   python = "==3.12.1"
 
   [tool.poetry.group.dev.dependencies]
-  commitizen = "==3.13.0" # Keep in sync with .pre-commit-config.yaml.
+  # Keep in sync with .pre-commit-config.yaml.
+  commitizen = "==3.13.0"
   pre-commit = "==3.6.0"


### PR DESCRIPTION
#107 accidentally moved a comment about dependency sync alongside Commitizen, misleading people to think it only applied there. Revert the comment's position to the top of the Poetry development dependencies section to clarify that it applies to both Commitizen and pre-commit.